### PR TITLE
BugFix: Can't join arena agian after finishing

### DIFF
--- a/src/main/java/plugily/projects/buildbattle/arena/ArenaRegistry.java
+++ b/src/main/java/plugily/projects/buildbattle/arena/ArenaRegistry.java
@@ -48,6 +48,8 @@ public class ArenaRegistry {
 
   private static final List<BaseArena> arenas = new ArrayList<>();
   private static final Main plugin = JavaPlugin.getPlugin(Main.class);
+  //PlayerArenaMap??? This is redudant information? I don't get what you're trying to achieve here?
+  //TODO: remove playerArenaMap
   private static final Map<UUID, String> playerArenaMap = new HashMap<>();
 
   private static int bungeeArena = -999;
@@ -68,12 +70,23 @@ public class ArenaRegistry {
       return null;
     }
 
-    return getArena(playerArenaMap.get(p.getUniqueId()));
+    for (BaseArena arena : arenas) {
+      for (Player player : arena.getPlayers()) {
+        if (player.equals(p)) {
+          return arena;
+        }
+      }
+    }
+    return null;
+    //playerArenaMap??
+    //return getArena(playerArenaMap.get(p.getUniqueId()));
   }
 
   public static Map<UUID, String> getPlayerArenaMap() {
     return playerArenaMap;
   }
+  
+
 
   public static void registerArena(BaseArena arena) {
     Debugger.debug("Registering new game instance, " + arena.getID());


### PR DESCRIPTION
People could not join arenas again after finishing? @FaberoM added a playerArenaMap which I don't get why?? It never gets updated when a player leaves an arena and tehrefore create a bug. This method also seems reduntant as all the information needed is already in the getPlayers() from the arena object.

Commit from @FaberoM can be seen [here ](https://github.com/Plugily-Projects/BuildBattle/commit/051e588acb7ab390a9947053db62bf66ccb87c99)
This is a temporary fix. I think it's best to remove playerArenaMap entirely.