### PR TITLE
Better Bugfix: Players can't join new game.

### DIFF
--- a/src/main/java/plugily/projects/buildbattle/arena/impl/BaseArena.java
+++ b/src/main/java/plugily/projects/buildbattle/arena/impl/BaseArena.java
@@ -234,6 +234,9 @@ public class BaseArena extends BukkitRunnable {
 
   public void clearPlayers() {
     players.clear();
+    for(Player player: players){
+      ArenaRegistry.getPlayerArenaMap().remove(player.getUniqueId(), id);
+    }
   }
 
   public void addSpectator(Player player) {


### PR DESCRIPTION
@FaberoM added spectator mode however he forget to remove the players from the playerArenamap when people use clearPlayers() from the BaseArena object.
However how @FaberoM implemented spector mode seems redudant and in-efficient to me. I'd have a talk with him about it as keeping redundant information in the code leads to inconsistent data which leads to bugs.