### PR TITLE
Fix chat spam issue that spectator is teleported to end location when…

### DIFF
--- a/src/main/java/plugily/projects/buildbattle/arena/impl/SoloArena.java
+++ b/src/main/java/plugily/projects/buildbattle/arena/impl/SoloArena.java
@@ -341,7 +341,6 @@ public class SoloArena extends BaseArena {
         break;
       case ENDING:
         List<Player> players = getPlayers();
-        players.addAll(getSpectators());
         getScoreboardManager().stopAllScoreboards();
         if(getPlugin().getConfigPreferences().getOption(ConfigPreferences.Option.BUNGEE_ENABLED)) {
           getPlugin().getServer().setWhitelist(false);
@@ -354,6 +353,11 @@ public class SoloArena extends BaseArena {
           }
         }
         if(getTimer() <= 0) {
+          for(Player spectator: getSpectators()){
+            if(!players.contains(spectator)){
+              players.add(spectator)
+            }
+          }
           for(Player player : players) {
             User user = plugin.getUserManager().getUser(player);
             user.removeScoreboard(this);


### PR DESCRIPTION
… a game ends

Issue in ticket on discord: 

When a spectator watches a game and the game is over. it gets this spammed in chat. a lot of times. (i think for every plot)

This server is running Paper version git-Paper-132 (MC: 1.17.1)
BuildBattle version 4.5.1
No errors in the console