### PR TITLE
Improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.17.1-R0.1-SNAPSHOT</version>
+            <version>1.19.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
             <exclusions>
             	<exclusion>

--- a/src/main/java/plugily/projects/buildbattle/arena/ArenaEvents.java
+++ b/src/main/java/plugily/projects/buildbattle/arena/ArenaEvents.java
@@ -65,7 +65,6 @@ import plugily.projects.minigamesbox.classic.arena.PluginArenaEvents;
 import plugily.projects.minigamesbox.classic.handlers.language.MessageBuilder;
 import plugily.projects.minigamesbox.classic.utils.version.ServerVersion;
 import plugily.projects.minigamesbox.classic.utils.version.VersionUtils;
-import plugily.projects.minigamesbox.classic.utils.version.events.api.PlugilyEntityPickupItemEvent;
 import plugily.projects.minigamesbox.classic.utils.version.events.api.PlugilyPlayerInteractEntityEvent;
 import plugily.projects.minigamesbox.classic.utils.version.events.api.PlugilyPlayerInteractEvent;
 import plugily.projects.minigamesbox.classic.utils.version.events.api.PlugilyPlayerPickupArrow;
@@ -514,7 +513,7 @@ public class ArenaEvents extends PluginArenaEvents {
       return;
     }
     Player player = (Player) event.getEntity();
-    if(plugin.getArenaRegistry().getArena(player) == null) {
+    if(!plugin.getArenaRegistry().isInArena(player)) {
       return;
     }
     event.setCancelled(true);
@@ -548,24 +547,6 @@ public class ArenaEvents extends PluginArenaEvents {
       e.getItem().remove();
       e.setCancelled(true);
     }
-  }
-
-  @EventHandler
-  public void onItemPickup(PlugilyEntityPickupItemEvent e) {
-    if(!(e.getEntity() instanceof Player)) {
-      return;
-    }
-    Player player = (Player) e.getEntity();
-    BaseArena pluginBaseArena = plugin.getArenaRegistry().getArena(player);
-    if(pluginBaseArena == null) {
-      return;
-    }
-    e.setCancelled(true);
-
-    // User user = plugin.getUserManager().getUser(player);
-    // if(user.isSpectator() || pluginBaseArena.getArenaState() != ArenaState.IN_GAME) {
-    //  return;
-    // }
   }
 
 

--- a/src/main/java/plugily/projects/buildbattle/arena/BaseArena.java
+++ b/src/main/java/plugily/projects/buildbattle/arena/BaseArena.java
@@ -136,8 +136,7 @@ public class BaseArena extends PluginArena {
    */
   @NotNull
   public String getTheme() {
-    //make sure to have no NPE
-    return theme == null ? "Theme" : theme;
+    return theme;
   }
 
   public void setTheme(String theme) {

--- a/src/main/java/plugily/projects/buildbattle/arena/managers/plots/Plot.java
+++ b/src/main/java/plugily/projects/buildbattle/arena/managers/plots/Plot.java
@@ -128,9 +128,9 @@ public class Plot {
       StringBuilder member = new StringBuilder();
       members.forEach(player -> member.append(player.getName()).append(" & "));
       return member.substring(0, member.length() - 3);
-    } else {
-      return "PLAYER_NOT_FOUND";
     }
+
+    return "PLAYER_NOT_FOUND";
   }
 
   public int getMembersSize() {

--- a/src/main/java/plugily/projects/buildbattle/arena/managers/plots/PlotMenuHandler.java
+++ b/src/main/java/plugily/projects/buildbattle/arena/managers/plots/PlotMenuHandler.java
@@ -21,12 +21,8 @@
 package plugily.projects.buildbattle.arena.managers.plots;
 
 import org.bukkit.Bukkit;
-import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Player;
-import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
-import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
 import plugily.projects.buildbattle.Main;
 import plugily.projects.buildbattle.api.event.plot.PlotPlayerChooseEvent;
@@ -34,6 +30,7 @@ import plugily.projects.buildbattle.arena.BaseArena;
 import plugily.projects.minigamesbox.classic.handlers.items.SpecialItem;
 import plugily.projects.minigamesbox.classic.handlers.language.MessageBuilder;
 import plugily.projects.minigamesbox.classic.utils.helper.ItemBuilder;
+import plugily.projects.minigamesbox.classic.utils.items.HandlerItem;
 import plugily.projects.minigamesbox.classic.utils.version.VersionUtils;
 import plugily.projects.minigamesbox.classic.utils.version.xseries.XMaterial;
 import plugily.projects.minigamesbox.inventory.common.item.SimpleClickableItem;
@@ -46,7 +43,7 @@ import java.util.List;
  * Created by Tigerpanzer_02 on 26/Jul/2021.
  */
 
-public class PlotMenuHandler implements Listener {
+public final class PlotMenuHandler {
 
   private final Main plugin;
   private final ItemStack empty;
@@ -59,28 +56,26 @@ public class PlotMenuHandler implements Listener {
     this.plugin = plugin;
     this.baseItem = plugin.getSpecialItemManager().getSpecialItem("PLOT_SELECTOR");
 
-    empty = XMaterial.GREEN_WOOL.parseItem().clone();
-    waiting = XMaterial.YELLOW_WOOL.parseItem().clone();
-    full = XMaterial.RED_WOOL.parseItem().clone();
-    inside = XMaterial.PINK_WOOL.parseItem().clone();
-
-    plugin.getServer().getPluginManager().registerEvents(this, plugin);
+    empty = XMaterial.GREEN_WOOL.parseItem();
+    waiting = XMaterial.YELLOW_WOOL.parseItem();
+    full = XMaterial.RED_WOOL.parseItem();
+    inside = XMaterial.PINK_WOOL.parseItem();
   }
 
   private ItemStack getItemStack(Plot plot, int maxPlotMembers, Player player) {
     if(plot.getMembers().isEmpty()) {
-      return empty;
+      return empty.clone();
     }
 
-    if(plot.getMembers().contains(player)) {
-      return inside;
+    if(plot.getMembers().indexOf(player) != -1) {
+      return inside.clone();
     }
 
-    if(plot.getMembers().size() == maxPlotMembers) {
-      return full;
+    if(plot.getMembersSize() == maxPlotMembers) {
+      return full.clone();
     }
 
-    return waiting;
+    return waiting.clone();
   }
 
   public void createMenu(Player player, BaseArena arena) {
@@ -94,33 +89,48 @@ public class PlotMenuHandler implements Listener {
 
       itemStack.setAmount(plotMemberSize == 0 ? 1 : plotMemberSize);
 
-      if(plotMemberSize >= arenaPlotMemberSize) {
-        itemStack = new ItemBuilder(itemStack).lore(new MessageBuilder("IN_GAME_MESSAGES_PLOT_SELECTOR_FULL").asKey().build()).build();
-      } else {
-        itemStack = new ItemBuilder(itemStack).lore(new MessageBuilder("IN_GAME_MESSAGES_PLOT_SELECTOR_EMPTY").asKey().build()).build();
-      }
+      itemStack = new ItemBuilder(itemStack).lore(new MessageBuilder(plotMemberSize >= arenaPlotMemberSize ? "IN_GAME_MESSAGES_PLOT_SELECTOR_FULL"
+          : "IN_GAME_MESSAGES_PLOT_SELECTOR_EMPTY").asKey().build()).build();
+
       if(plotMemberSize != 0) {
         List<String> players = new ArrayList<>(plotMemberSize);
-        for(Player plotMembers : plot.getMembers()) {
-          players.add("- " + plotMembers.getName());
+
+        for(Player plotMember : plot.getMembers()) {
+          players.add("- " + plotMember.getName());
         }
+
         itemStack = new ItemBuilder(itemStack).lore(players).build();
       }
-      if(plot.getMembers().contains(player)) {
+
+      if(plot.getMembers().indexOf(player) != -1) {
         itemStack = new ItemBuilder(itemStack).lore(new MessageBuilder("IN_GAME_MESSAGES_PLOT_SELECTOR_INSIDE").asKey().build()).build();
       }
+
       itemStack = new ItemBuilder(itemStack).name(new MessageBuilder("IN_GAME_MESSAGES_PLOT_SELECTOR_NAME").asKey().integer(plots).build()).build();
+
+      new HandlerItem(itemStack).addInteractHandler(event -> {
+        if(!(event.getAction() == Action.RIGHT_CLICK_AIR || event.getAction() == Action.RIGHT_CLICK_BLOCK)) {
+          return;
+        }
+
+        if(!VersionUtils.getItemInHand(event.getPlayer()).equals(baseItem.getItemStack())) {
+          return;
+        }
+
+        BaseArena baseArena = plugin.getArenaRegistry().getArena(event.getPlayer());
+        if(baseArena == null) {
+          return;
+        }
+
+        event.setCancelled(true);
+        createMenu(event.getPlayer(), baseArena);
+      });
+
       int finalPlots = plots;
       gui.addItem(new SimpleClickableItem(itemStack, event -> {
         event.setCancelled(true);
 
         if(!(event.isLeftClick() || event.isRightClick())) {
-          return;
-        }
-
-        HumanEntity humanEntity = event.getWhoClicked();
-
-        if (!(humanEntity instanceof Player)) {
           return;
         }
 
@@ -132,7 +142,7 @@ public class PlotMenuHandler implements Listener {
         }
 
         new MessageBuilder("IN_GAME_MESSAGES_PLOT_SELECTOR_PLOT_CHOOSE").asKey().player(player).integer(finalPlots).sendPlayer();
-        humanEntity.closeInventory();
+        event.getWhoClicked().closeInventory();
       }));
 
       plots++;
@@ -140,25 +150,6 @@ public class PlotMenuHandler implements Listener {
 
     gui.refresh();
     gui.open(player);
-  }
-
-  @EventHandler
-  public void onPlotMenuItemClick(PlayerInteractEvent e) {
-    if(!(e.getAction() == Action.RIGHT_CLICK_AIR || e.getAction() == Action.RIGHT_CLICK_BLOCK)) {
-      return;
-    }
-
-    if(!VersionUtils.getItemInHand(e.getPlayer()).equals(baseItem.getItemStack())) {
-      return;
-    }
-
-    BaseArena arena = plugin.getArenaRegistry().getArena(e.getPlayer());
-    if(arena == null) {
-      return;
-    }
-
-    e.setCancelled(true);
-    createMenu(e.getPlayer(), arena);
   }
 
 }

--- a/src/main/java/plugily/projects/buildbattle/arena/managers/plots/PlotMenuHandler.java
+++ b/src/main/java/plugily/projects/buildbattle/arena/managers/plots/PlotMenuHandler.java
@@ -31,6 +31,7 @@ import plugily.projects.minigamesbox.classic.handlers.items.SpecialItem;
 import plugily.projects.minigamesbox.classic.handlers.language.MessageBuilder;
 import plugily.projects.minigamesbox.classic.utils.helper.ItemBuilder;
 import plugily.projects.minigamesbox.classic.utils.items.HandlerItem;
+import plugily.projects.minigamesbox.classic.utils.items.ItemManager;
 import plugily.projects.minigamesbox.classic.utils.version.VersionUtils;
 import plugily.projects.minigamesbox.classic.utils.version.xseries.XMaterial;
 import plugily.projects.minigamesbox.inventory.common.item.SimpleClickableItem;
@@ -108,7 +109,9 @@ public final class PlotMenuHandler {
 
       itemStack = new ItemBuilder(itemStack).name(new MessageBuilder("IN_GAME_MESSAGES_PLOT_SELECTOR_NAME").asKey().integer(plots).build()).build();
 
-      new HandlerItem(itemStack).addInteractHandler(event -> {
+      HandlerItem handlerItem = new HandlerItem(itemStack);
+
+      handlerItem.addInteractHandler(event -> {
         if(!(event.getAction() == Action.RIGHT_CLICK_AIR || event.getAction() == Action.RIGHT_CLICK_BLOCK)) {
           return;
         }
@@ -125,6 +128,8 @@ public final class PlotMenuHandler {
         event.setCancelled(true);
         createMenu(event.getPlayer(), baseArena);
       });
+
+      ItemManager.addItem(handlerItem);
 
       int finalPlots = plots;
       gui.addItem(new SimpleClickableItem(itemStack, event -> {

--- a/src/main/java/plugily/projects/buildbattle/arena/vote/VoteEvents.java
+++ b/src/main/java/plugily/projects/buildbattle/arena/vote/VoteEvents.java
@@ -51,11 +51,11 @@ public class VoteEvents implements Listener {
 
   @EventHandler
   public void onVote(PlugilyPlayerInteractEvent event) {
-    if(VersionUtils.checkOffHand(event.getHand()) || event.getAction() == Action.LEFT_CLICK_AIR || event.getAction() == Action.LEFT_CLICK_BLOCK || event.getAction() == Action.PHYSICAL) {
+    if(event.getAction() == Action.LEFT_CLICK_AIR || event.getAction() == Action.LEFT_CLICK_BLOCK || event.getAction() == Action.PHYSICAL) {
       return;
     }
 
-    if(!ItemUtils.isItemStackNamed(event.getItem())) {
+    if(VersionUtils.checkOffHand(event.getHand()) || !ItemUtils.isItemStackNamed(event.getItem())) {
       return;
     }
 

--- a/src/main/java/plugily/projects/buildbattle/commands/arguments/admin/plot/SelectPlotArgument.java
+++ b/src/main/java/plugily/projects/buildbattle/commands/arguments/admin/plot/SelectPlotArgument.java
@@ -41,7 +41,7 @@ public class SelectPlotArgument {
         Player player = (Player) sender;
         BaseArena arena = (BaseArena) registry.getPlugin().getArenaRegistry().getArena(player);
 
-        if(arena != null && arena.getArenaState() == ArenaState.WAITING_FOR_PLAYERS || arena.getArenaState() == ArenaState.STARTING)
+        if(arena != null && (arena.getArenaState() == ArenaState.WAITING_FOR_PLAYERS || arena.getArenaState() == ArenaState.STARTING))
           arena.getPlugin().getPlotMenuHandler().createMenu(player, arena);
       }
     });

--- a/src/main/java/plugily/projects/buildbattle/handlers/menu/OptionsMenuHandler.java
+++ b/src/main/java/plugily/projects/buildbattle/handlers/menu/OptionsMenuHandler.java
@@ -54,12 +54,12 @@ public class OptionsMenuHandler implements Listener {
       return;
     }
 
-    BaseArena arena = plugin.getArenaRegistry().getArena((Player) humanEntity);
-    if(arena == null || arena.getArenaState() != ArenaState.IN_GAME) {
+    if(event.getInventory() != plugin.getOptionsRegistry().formatInventory()) {
       return;
     }
 
-    if(event.getInventory() != plugin.getOptionsRegistry().formatInventory()) {
+    BaseArena arena = plugin.getArenaRegistry().getArena((Player) humanEntity);
+    if(arena == null || arena.getArenaState() != ArenaState.IN_GAME) {
       return;
     }
 

--- a/src/main/java/plugily/projects/buildbattle/handlers/menu/OptionsMenuHandler.java
+++ b/src/main/java/plugily/projects/buildbattle/handlers/menu/OptionsMenuHandler.java
@@ -30,8 +30,6 @@ import org.bukkit.inventory.ItemStack;
 import plugily.projects.buildbattle.Main;
 import plugily.projects.buildbattle.arena.BaseArena;
 import plugily.projects.minigamesbox.classic.arena.ArenaState;
-import plugily.projects.minigamesbox.classic.handlers.language.MessageBuilder;
-import plugily.projects.minigamesbox.classic.utils.helper.ItemUtils;
 import plugily.projects.minigamesbox.classic.utils.misc.complement.ComplementAccessor;
 
 /**
@@ -56,20 +54,22 @@ public class OptionsMenuHandler implements Listener {
       return;
     }
 
-    ItemStack currentItem = event.getCurrentItem();
-
-    if(!ItemUtils.isItemStackNamed(currentItem)
-        || !ComplementAccessor.getComplement().getTitle(event.getView()).equals(new MessageBuilder("MENU_OPTION_INVENTORY").asKey().build())) {
-      return;
-    }
     BaseArena arena = plugin.getArenaRegistry().getArena((Player) humanEntity);
     if(arena == null || arena.getArenaState() != ArenaState.IN_GAME) {
       return;
     }
+
+    if(event.getInventory() != plugin.getOptionsRegistry().formatInventory()) {
+      return;
+    }
+
+    ItemStack currentItem = event.getCurrentItem();
+
     for(MenuOption option : plugin.getOptionsRegistry().getRegisteredOptions()) {
       if(!option.getItemStack().isSimilar(currentItem)) {
         continue;
       }
+
       event.setCancelled(true);
       option.onClick(event);
       return;
@@ -84,13 +84,7 @@ public class OptionsMenuHandler implements Listener {
       return;
     }
 
-    ItemStack currentItem = event.getCurrentItem();
-
-    if (!ItemUtils.isItemStackNamed(currentItem))
-      return;
-
-    if(ComplementAccessor.getComplement().getDisplayName(plugin.getOptionsRegistry().getGoBackItem().getItemMeta())
-        .equalsIgnoreCase(ComplementAccessor.getComplement().getDisplayName(currentItem.getItemMeta()))) {
+    if(plugin.getOptionsRegistry().getGoBackItem().isSimilar(event.getCurrentItem())) {
       event.setCancelled(true);
       human.closeInventory();
       human.openInventory(plugin.getOptionsRegistry().formatInventory());

--- a/src/main/java/plugily/projects/buildbattle/handlers/menu/OptionsRegistry.java
+++ b/src/main/java/plugily/projects/buildbattle/handlers/menu/OptionsRegistry.java
@@ -57,6 +57,8 @@ public class OptionsRegistry {
   private final ItemStack menuItem;
   private final Main plugin;
 
+  private Inventory optionsInventory;
+
   public OptionsRegistry(Main plugin) {
     this.plugin = plugin;
     this.menuItem = plugin.getSpecialItemManager().getSpecialItemStack("OPTIONS_MENU");
@@ -128,11 +130,16 @@ public class OptionsRegistry {
    * @return options inventory
    */
   public Inventory formatInventory() {
+    if (optionsInventory != null)
+      return optionsInventory;
+
     Inventory inv = ComplementAccessor.getComplement().createInventory(null, inventorySize, new MessageBuilder("MENU_OPTION_INVENTORY").asKey().build());
+
     for(MenuOption option : registeredOptions) {
       inv.setItem(option.getSlot(), option.getItemStack());
     }
-    return inv;
+
+    return optionsInventory = inv;
   }
 
   public Set<MenuOption> getRegisteredOptions() {

--- a/src/main/java/plugily/projects/buildbattle/handlers/menu/registry/banner/BannerCreatorOption.java
+++ b/src/main/java/plugily/projects/buildbattle/handlers/menu/registry/banner/BannerCreatorOption.java
@@ -20,6 +20,7 @@
 
 package plugily.projects.buildbattle.handlers.menu.registry.banner;
 
+import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
 
@@ -42,9 +43,14 @@ public class BannerCreatorOption {
         .lore(new MessageBuilder("MENU_OPTION_CONTENT_BANNER_ITEM_LORE").asKey().build())
         .build()) {
       @Override
-      public void onClick(InventoryClickEvent e) {
-        e.getWhoClicked().closeInventory();
-        new BannerMenu((Player) e.getWhoClicked()).openInventory(BannerMenu.PatternStage.BASE);
+      public void onClick(InventoryClickEvent event) {
+        HumanEntity humanEntity = event.getWhoClicked();
+
+        humanEntity.closeInventory();
+
+        if (humanEntity instanceof Player) {
+          new BannerMenu((Player) humanEntity).openInventory(BannerMenu.PatternStage.BASE);
+        }
       }
     });
   }

--- a/src/main/java/plugily/projects/buildbattle/handlers/menu/registry/banner/BannerMenu.java
+++ b/src/main/java/plugily/projects/buildbattle/handlers/menu/registry/banner/BannerMenu.java
@@ -35,6 +35,7 @@ import plugily.projects.minigamesbox.inventory.common.item.SimpleClickableItem;
 import plugily.projects.minigamesbox.inventory.normal.NormalFastInv;
 
 import java.util.EnumMap;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -80,7 +81,7 @@ public class BannerMenu {
         }
         item.setItemMeta(meta);
       } else {
-        item = XMaterial.matchXMaterial(color.toString().toUpperCase() + "_BANNER").get().parseItem();
+        item = XMaterial.matchXMaterial(color.toString().toUpperCase(Locale.ENGLISH) + "_BANNER").get().parseItem();
       }
       gui.addItem(new SimpleClickableItem(item, e -> {
         e.setCancelled(true);

--- a/src/main/java/plugily/projects/buildbattle/handlers/menu/registry/particles/ParticleRefreshScheduler.java
+++ b/src/main/java/plugily/projects/buildbattle/handlers/menu/registry/particles/ParticleRefreshScheduler.java
@@ -49,10 +49,7 @@ public class ParticleRefreshScheduler {
 
     task = Bukkit.getScheduler().runTaskTimer(plugin, () -> {
       for(PluginArena arena : plugin.getArenaRegistry().getArenas()) {
-        if(!(arena instanceof BaseArena)) {
-          continue;
-        }
-        if(!arena.getPlayers().isEmpty()) {
+        if(arena instanceof BaseArena && !arena.getPlayers().isEmpty()) {
           for(Plot buildPlot : ((BaseArena) arena).getPlotManager().getPlots()) {
             if(!buildPlot.getMembers().isEmpty()) {
               for(Entry<Location, String> map : buildPlot.getParticles().entrySet()) {

--- a/src/main/java/plugily/projects/buildbattle/handlers/menu/registry/playerheads/PlayerHeadsRegistry.java
+++ b/src/main/java/plugily/projects/buildbattle/handlers/menu/registry/playerheads/PlayerHeadsRegistry.java
@@ -96,7 +96,7 @@ public class PlayerHeadsRegistry {
 
   public boolean isHeadsMenu(Inventory inventory) {
     for(Inventory inv : categories.values()) {
-      if(inv.equals(inventory)) {
+      if(inv == inventory) {
         return true;
       }
     }

--- a/src/main/java/plugily/projects/buildbattle/handlers/themes/vote/VoteMenu.java
+++ b/src/main/java/plugily/projects/buildbattle/handlers/themes/vote/VoteMenu.java
@@ -24,6 +24,7 @@ import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -103,7 +104,14 @@ public class VoteMenu {
 
     gui.addCloseHandler(event -> {
       if(arena.getArenaInGameStage() == BaseArena.ArenaInGameStage.THEME_VOTING) {
-        event.getPlayer().openInventory(event.getInventory());
+        plugin.getServer().getScheduler().runTaskLater(plugin, () -> {
+          HumanEntity humanEntity = event.getPlayer();
+          Inventory inventory = event.getInventory();
+
+          if (humanEntity.getOpenInventory().getTopInventory() != inventory) {
+            humanEntity.openInventory(inventory);
+          }
+        }, 3); // Delay operation to make sure the top inventory is closed before opening again
       }
     });
 

--- a/src/main/java/plugily/projects/buildbattle/handlers/themes/vote/VoteMenu.java
+++ b/src/main/java/plugily/projects/buildbattle/handlers/themes/vote/VoteMenu.java
@@ -104,14 +104,14 @@ public class VoteMenu {
 
     gui.addCloseHandler(event -> {
       if(arena.getArenaInGameStage() == BaseArena.ArenaInGameStage.THEME_VOTING) {
-        plugin.getServer().getScheduler().runTaskLater(plugin, () -> {
+        plugin.getServer().getScheduler().runTask(plugin, () -> {
           HumanEntity humanEntity = event.getPlayer();
           Inventory inventory = event.getInventory();
 
           if (humanEntity.getOpenInventory().getTopInventory() != inventory) {
             humanEntity.openInventory(inventory);
           }
-        }, 3); // Delay operation to make sure the top inventory is closed before opening again
+        });
       }
     });
 


### PR DESCRIPTION
This PR contains these fixes/changes:
- Another StackOverflowError for VoteMenu close event, now it seems to work now
- Removed the pickup event to allow for players to pickup items from the ground while in an arena (because why not, they can't do anything wrong I guess)
- Updated Paper api to 1.19.2
- Fixed text duplications for VoteMenu items, we need to deep copy those items to avoid overriding
- Fixed when players can not build in arena after vote phase
- Improved the inventory checking in OptionsMenu, so the options inventory is now cached
- Now changing floor by clicking on the Villager works

During testing I met an issue with duplicating the menu item using the drop key. I think this is not a big one issue, players can duplicate those items as many times as they want, they can't do anything wrong with that, so I didn't fixed this.

Similar PR #58