### PR TITLE
Allow disabling of Super Votes

### DIFF
--- a/src/main/java/plugily/projects/buildbattle/boot/AdditionalValueInitializer.java
+++ b/src/main/java/plugily/projects/buildbattle/boot/AdditionalValueInitializer.java
@@ -60,6 +60,7 @@ public class AdditionalValueInitializer {
     configPreferences.registerOption("REPORT_COMMANDS", new ConfigOption("Report.Commands", false));
     configPreferences.registerOption("PLOT_HIDE_OWNER", new ConfigOption("Plot.Hide-Owner", false));
     configPreferences.registerOption("PLOT_MOVE_OUTSIDE", new ConfigOption("Plot.Move-Outside", false));
+    configPreferences.registerOption("SUPER_VOTES", new ConfigOption("Super-Votes", true));
   }
 
   private void registerStatistics() {

--- a/src/main/java/plugily/projects/buildbattle/handlers/themes/vote/VoteMenu.java
+++ b/src/main/java/plugily/projects/buildbattle/handlers/themes/vote/VoteMenu.java
@@ -130,25 +130,30 @@ public class VoteMenu {
 
       setGlassPanes(gui, multiplied, percent);
 
-      gui.setItem(multiplied + 8, new SimpleClickableItem(new ItemBuilder(new ItemStack(Material.PAPER))
-          .name(new MessageBuilder("MENU_THEME_VOTE_SUPER_ITEM_NAME").asKey().arena(arena).value(theme).build())
-          .lore(new MessageBuilder("MENU_THEME_VOTE_SUPER_ITEM_LORE").asKey().player(guiPlayer).arena(arena).value(theme).build().split(";"))
-          .build(), event -> {
-        HumanEntity humanEntity = event.getWhoClicked();
+      if (plugin.getConfigPreferences().getOption("SUPER_VOTES")) {
+        gui.setItem(multiplied + 8, new SimpleClickableItem(new ItemBuilder(new ItemStack(Material.PAPER))
+            .name(new MessageBuilder("MENU_THEME_VOTE_SUPER_ITEM_NAME").asKey().arena(arena).value(theme).build())
+            .lore(new MessageBuilder("MENU_THEME_VOTE_SUPER_ITEM_LORE").asKey().player(guiPlayer).arena(arena).value(theme).build().split(";"))
+            .build(), event -> {
+          HumanEntity humanEntity = event.getWhoClicked();
 
-        if(!(humanEntity instanceof Player))
-          return;
+          if(!(humanEntity instanceof Player))
+            return;
 
-        Player player = (Player) humanEntity;
-        User user = plugin.getUserManager().getUser(player);
+          Player player = (Player) humanEntity;
+          User user = plugin.getUserManager().getUser(player);
 
-        if(user.getStatistic("SUPER_VOTES") > 0) {
-          user.adjustStatistic("SUPER_VOTES", -1);
-          new MessageBuilder("MENU_THEME_VOTE_SUPER_USED").asKey().arena(arena).player(player).value(theme).sendArena();
-          arena.setTheme(theme);
-          arena.setTimer(0, true);
-        }
-      }));
+          if(user.getStatistic("SUPER_VOTES") > 0) {
+            user.adjustStatistic("SUPER_VOTES", -1);
+            new MessageBuilder("MENU_THEME_VOTE_SUPER_USED").asKey().arena(arena).player(player).value(theme).sendArena();
+            arena.setTheme(theme);
+            arena.setTimer(0, true);
+          }
+        }));
+      }
+      else {
+        gui.setItem(multiplied + 8, ClickableItem.of(new ItemBuilder(XMaterial.IRON_BARS.parseItem()).name("&7<-").colorizeItem().build()));
+      }
 
       i++;
     }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -81,6 +81,10 @@ Database: false
 Rewards: false
 
 
+# Enable the super votes in the theme vote menu
+Super-Votes: true
+
+
 Chat:
   # Enable in game (eg. '[KIT][LEVEL] Tigerpanzer_02: hey') special formatting?
   # Formatting is configurable in language.yml


### PR DESCRIPTION
Add a config option to disable super votes in the theme vote menu
```yaml
# Enable the super votes in the theme vote menu
Super-Votes: true
```
If they are disabled, the spot is replaced with iron bars.
![Screenshot from 2024-06-11 00-43-35](https://github.com/Plugily-Projects/BuildBattle/assets/69283684/43e8f798-ecd5-42cf-8f8f-aba51fdafc9f)
