### PR TITLE
Fixed many bugs in BuildBattle plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,7 @@ repositories {
 }
 
 dependencies {
-    implementation("plugily.projects:MiniGamesBox-Classic:1.3.10-waterman") { isTransitive = false }
+    implementation("plugily.projects:MiniGamesBox-Classic:1.3.10") { isTransitive = false }
     compileOnly("org.spigotmc:spigot-api:1.20.4-R0.1-SNAPSHOT")
     compileOnly("io.papermc.paper:paper-api:1.20.4-R0.1-SNAPSHOT")
     compileOnly("net.citizensnpcs:citizensapi:2.0.31-SNAPSHOT")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,7 @@ repositories {
 }
 
 dependencies {
-    implementation("plugily.projects:MiniGamesBox-Classic:1.3.10") { isTransitive = false }
+    implementation("plugily.projects:MiniGamesBox-Classic:1.3.10-waterman") { isTransitive = false }
     compileOnly("org.spigotmc:spigot-api:1.20.4-R0.1-SNAPSHOT")
     compileOnly("io.papermc.paper:paper-api:1.20.4-R0.1-SNAPSHOT")
     compileOnly("net.citizensnpcs:citizensapi:2.0.31-SNAPSHOT")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,7 +38,7 @@ repositories {
 }
 
 dependencies {
-    implementation("plugily.projects:MiniGamesBox-Classic:1.3.7") { isTransitive = false }
+    implementation("plugily.projects:MiniGamesBox-Classic:1.3.8-waterman") { isTransitive = false }
     compileOnly("org.spigotmc:spigot-api:1.19.3-R0.1-SNAPSHOT")
     compileOnly("net.citizensnpcs:citizensapi:2.0.31-SNAPSHOT")
     compileOnly("org.jetbrains:annotations:24.0.1")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,7 +45,7 @@ dependencies {
 }
 
 group = "plugily.projects"
-version = "5.0.5-SNAPSHOT1"
+version = "5.0.6"
 description = "BuildBattle"
 
 java {

--- a/src/main/java/plugily/projects/buildbattle/arena/ArenaEvents.java
+++ b/src/main/java/plugily/projects/buildbattle/arena/ArenaEvents.java
@@ -418,6 +418,8 @@ public class ArenaEvents extends PluginArenaEvents {
     event.setCancelled(true);
   }
 
+
+
   @EventHandler(priority = EventPriority.HIGH)
   public void onDamage(EntityDamageEvent event) {
     if(event.getEntity().getType() != EntityType.PLAYER) {
@@ -482,6 +484,17 @@ public class ArenaEvents extends PluginArenaEvents {
           event.setCancelled(true);
         }
       }
+    }
+  }
+
+  @EventHandler
+  public void onEnderpearlThrow(ProjectileLaunchEvent event) {
+    BaseArena arena = plugin.getArenaRegistry().getArena((Player) event.getEntity().getShooter());
+    if(arena == null || arena.getArenaState() != IArenaState.IN_GAME) {
+      return;
+    }
+    if(event.getEntity() instanceof EnderPearl) {
+      event.setCancelled(true);
     }
   }
 

--- a/src/main/java/plugily/projects/buildbattle/arena/ArenaEvents.java
+++ b/src/main/java/plugily/projects/buildbattle/arena/ArenaEvents.java
@@ -469,6 +469,23 @@ public class ArenaEvents extends PluginArenaEvents {
   }
 
   @EventHandler
+  public void onOtherBlockExplode(BlockExplodeEvent event) {
+    Location blockLocation = event.getBlock().getLocation();
+
+    for(IPluginArena arena : plugin.getArenaRegistry().getArenas()) {
+      if(!(arena instanceof BaseArena)) {
+        continue;
+      }
+      for(Plot buildPlot : ((BaseArena) arena).getPlotManager().getPlots()) {
+        if(buildPlot.getCuboid() != null && buildPlot.getCuboid().isInWithMarge(blockLocation, 5)) {
+          event.blockList().clear();
+          event.setCancelled(true);
+        }
+      }
+    }
+  }
+
+  @EventHandler
   public void onWaterFlowEvent(BlockFromToEvent event) {
     Location toBlock = event.getToBlock().getLocation();
     Location blockLoc = event.getBlock().getLocation();

--- a/src/main/java/plugily/projects/buildbattle/arena/ArenaEvents.java
+++ b/src/main/java/plugily/projects/buildbattle/arena/ArenaEvents.java
@@ -489,12 +489,14 @@ public class ArenaEvents extends PluginArenaEvents {
 
   @EventHandler
   public void onEnderpearlThrow(ProjectileLaunchEvent event) {
-    BaseArena arena = plugin.getArenaRegistry().getArena((Player) event.getEntity().getShooter());
-    if(arena == null || arena.getArenaState() != IArenaState.IN_GAME) {
-      return;
-    }
-    if(event.getEntity() instanceof EnderPearl) {
-      event.setCancelled(true);
+    if(event.getEntity().getShooter() instanceof Player) {
+      BaseArena arena = plugin.getArenaRegistry().getArena((Player) event.getEntity().getShooter());
+      if (arena == null || arena.getArenaState() != IArenaState.IN_GAME) {
+        return;
+      }
+      if (event.getEntity() instanceof EnderPearl) {
+        event.setCancelled(true);
+      }
     }
   }
 

--- a/src/main/java/plugily/projects/buildbattle/arena/ArenaEvents.java
+++ b/src/main/java/plugily/projects/buildbattle/arena/ArenaEvents.java
@@ -550,15 +550,6 @@ public class ArenaEvents extends PluginArenaEvents {
   }
 
   @EventHandler
-  public void onInventoryClose(InventoryCloseEvent event) {
-    Player player = (Player) event.getPlayer();
-    BaseArena baseArena = plugin.getArenaRegistry().getArena(player);
-    if(baseArena != null && baseArena.getArenaInGameState() == BaseArena.ArenaInGameState.BUILD_TIME) {
-      baseArena.addMenuItem(player);
-    }
-  }
-
-  @EventHandler
   public void onItemMove(InventoryClickEvent event) {
     HumanEntity humanEntity = event.getWhoClicked();
 

--- a/src/main/java/plugily/projects/buildbattle/arena/BaseArena.java
+++ b/src/main/java/plugily/projects/buildbattle/arena/BaseArena.java
@@ -217,33 +217,6 @@ public class BaseArena extends PluginArena {
     }
   }
 
-  HandlerItem optionsMenuItem;
-
-  private HandlerItem getMenuItem() {
-    if(optionsMenuItem == null) {
-      HandlerItem optionsMenu = new HandlerItem(getPlugin().getOptionsRegistry().getMenuItem());
-      optionsMenu.setLeftClick(true);
-      optionsMenu.setRightClick(true);
-      optionsMenu.addInteractHandler(event -> {
-        event.setCancelled(true);
-        getPlugin().getOptionsRegistry().getOptionsGui().open(event.getPlayer());
-      });
-      optionsMenu.addInventoryClickHandler(event -> {
-        getPlugin().getOptionsRegistry().getOptionsGui().open(event.getWhoClicked());
-      });
-      optionsMenuItem = optionsMenu.build();
-    }
-    return optionsMenuItem;
-  }
-
-  public void addMenuItem(Player player) {
-    if(player.getInventory().contains(getMenuItem().getItemStack())) {
-      return;
-    }
-    player.getInventory().setItem(8, getMenuItem().getItemStack());
-  }
-
-
   public PlotManager getPlotManager() {
     return plotManager;
   }

--- a/src/main/java/plugily/projects/buildbattle/arena/managers/plots/PlotManager.java
+++ b/src/main/java/plugily/projects/buildbattle/arena/managers/plots/PlotManager.java
@@ -119,7 +119,7 @@ public class PlotManager {
             Bukkit.getScheduler().runTaskLater(arena.getPlugin(), () -> {
               player.setAllowFlight(true);
               player.setFlying(true);
-            }, 40);
+            }, 2);
           }
         });
       }

--- a/src/main/java/plugily/projects/buildbattle/arena/states/build/InGameState.java
+++ b/src/main/java/plugily/projects/buildbattle/arena/states/build/InGameState.java
@@ -103,8 +103,8 @@ public class InGameState extends PluginInGameState {
             adjustStatistics(pluginArena);
 
             pluginArena.teleportToWinnerPlot();
-            pluginArena.executeEndRewards();
             getPlugin().getArenaManager().stopGame(false, arena);
+            pluginArena.executeEndRewards();
           } else {
             voteForNextPlot(pluginArena);
           }

--- a/src/main/java/plugily/projects/buildbattle/arena/states/build/InGameState.java
+++ b/src/main/java/plugily/projects/buildbattle/arena/states/build/InGameState.java
@@ -65,7 +65,6 @@ public class InGameState extends PluginInGameState {
 
           for(Player player : pluginArena.getPlayers()) {
             player.closeInventory();
-            pluginArena.addMenuItem(player);
             player.setGameMode(GameMode.CREATIVE);
           }
         } else {

--- a/src/main/java/plugily/projects/buildbattle/arena/states/guess/InGameState.java
+++ b/src/main/java/plugily/projects/buildbattle/arena/states/guess/InGameState.java
@@ -72,7 +72,6 @@ public class InGameState extends PluginInGameState {
           new TitleBuilder("IN_GAME_MESSAGES_PLOT_GTB_THEME_GUESS_TITLE").asKey().arena(pluginArena).sendArena();
 
           Bukkit.getScheduler().runTaskLater(getPlugin(), () -> pluginArena.getCurrentBuilders().forEach(player -> player.setGameMode(GameMode.CREATIVE)), 40);
-          pluginArena.getCurrentBuilders().forEach(pluginArena::addMenuItem);
 
           setArenaTimer(getPlugin().getConfig().getInt("Time-Manager." + pluginArena.getArenaType().getPrefix() + ".In-Game"));
           pluginArena.setArenaInGameState(BaseArena.ArenaInGameState.BUILD_TIME);

--- a/src/main/java/plugily/projects/buildbattle/boot/AdditionalValueInitializer.java
+++ b/src/main/java/plugily/projects/buildbattle/boot/AdditionalValueInitializer.java
@@ -92,7 +92,7 @@ public class AdditionalValueInitializer {
     rewardsFactory.registerRewardType("VOTE", new RewardType("voted"));
     rewardsFactory.registerRewardType("VOTE_ALL", new RewardType("voted-all"));
     rewardsFactory.registerRewardType("REPORT", new RewardType("report"));
-    rewardsFactory.registerRewardType("PLACE", new RewardType("place"));
+    rewardsFactory.registerRewardType("PLACE", new RewardType("place", RewardType.ExecutorType.NUMBER, false));
   }
 
   private void registerSpecialItems() {

--- a/src/main/java/plugily/projects/buildbattle/commands/arguments/ArgumentsRegistry.java
+++ b/src/main/java/plugily/projects/buildbattle/commands/arguments/ArgumentsRegistry.java
@@ -30,6 +30,7 @@ import plugily.projects.buildbattle.commands.arguments.admin.plot.AddPlotArgumen
 import plugily.projects.buildbattle.commands.arguments.admin.plot.RemovePlotArgument;
 import plugily.projects.buildbattle.commands.arguments.admin.plot.SelectPlotArgument;
 import plugily.projects.buildbattle.commands.arguments.game.GuessArgument;
+import plugily.projects.buildbattle.commands.arguments.game.MenuArgument;
 import plugily.projects.minigamesbox.api.arena.IPluginArena;
 import plugily.projects.minigamesbox.classic.commands.arguments.PluginArgumentsRegistry;
 
@@ -50,6 +51,7 @@ public class ArgumentsRegistry extends PluginArgumentsRegistry {
     new AddPlotArgument(this);
     new RemovePlotArgument(this);
     new SelectPlotArgument(this);
+    new MenuArgument(this);
     new GuessArgument(this);
     new ThemeArgument(this);
   }

--- a/src/main/java/plugily/projects/buildbattle/commands/arguments/game/MenuArgument.java
+++ b/src/main/java/plugily/projects/buildbattle/commands/arguments/game/MenuArgument.java
@@ -1,0 +1,50 @@
+/*
+ *
+ * BuildBattle - Ultimate building competition minigame
+ * Copyright (C) 2022 Plugily Projects - maintained by Tigerpanzer_02 and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package plugily.projects.buildbattle.commands.arguments.game;
+
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import plugily.projects.buildbattle.arena.BaseArena;
+import plugily.projects.buildbattle.commands.arguments.ArgumentsRegistry;
+import plugily.projects.minigamesbox.api.arena.IArenaState;
+import plugily.projects.minigamesbox.classic.commands.arguments.data.CommandArgument;
+
+/**
+ * @author Tigerpanzer_02
+ * <p>
+ * Created at 27.12.2020
+ */
+public class MenuArgument {
+
+  public MenuArgument(ArgumentsRegistry registry) {
+    registry.mapArgument("buildbattle", new CommandArgument("menu", "", CommandArgument.ExecutorType.PLAYER) {
+      @Override
+      public void execute(CommandSender sender, String[] args) {
+        Player player = (Player) sender;
+        BaseArena arena = (BaseArena) registry.getPlugin().getArenaRegistry().getArena(player);
+
+        if(arena != null && (arena.getArenaState() == IArenaState.IN_GAME))
+          arena.getPlugin().getOptionsRegistry().getOptionsGui().open(player);
+      }
+    });
+  }
+
+}

--- a/src/main/java/plugily/projects/buildbattle/handlers/menu/registry/TimeChangeOption.java
+++ b/src/main/java/plugily/projects/buildbattle/handlers/menu/registry/TimeChangeOption.java
@@ -67,8 +67,9 @@ public class TimeChangeOption {
           return;
         }
 
-        gui.addItem(new ItemBuilder(XMaterial.CLOCK.parseItem()).name(new MessageBuilder("MENU_OPTION_CONTENT_TIME_TYPE_WORLD").asKey().build()).lore(plot.getTime().name()).build());
+        //gui.addItem(new ItemBuilder(XMaterial.CLOCK.parseItem()).name(new MessageBuilder("MENU_OPTION_CONTENT_TIME_TYPE_WORLD").asKey().build()).lore(plot.getTime().name()).build());
 
+        addClockItem(gui, plot, "MENU_OPTION_CONTENT_TIME_TYPE_WORLD");
         addClockItem(gui, plot, "MENU_OPTION_CONTENT_TIME_TYPE_DAY");
         addClockItem(gui, plot, "MENU_OPTION_CONTENT_TIME_TYPE_NOON");
         addClockItem(gui, plot, "MENU_OPTION_CONTENT_TIME_TYPE_SUNSET");

--- a/src/main/resources/language.yml
+++ b/src/main/resources/language.yml
@@ -393,7 +393,7 @@ Menu:
           Noon: "Noon (6000 ticks)"
           Sunset: "Sunset (12000 ticks)"
           Night: "Night (13000 ticks)"
-          MidNight: "MidNight (18000 ticks)"
+          MidNight: "Midnight (18000 ticks)"
           Sunrise: "Sunrise (23000 ticks)"
         Changed: "%plugin_prefix% Time has been changed to %value%"
       Biome:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -8,11 +8,11 @@ api-version: 1.13
 commands:
   buildbattle:
     description: BuildBattle Commands
-    usage: "\u00A76Correct usage: /bb [option]"
+    usage: "§6Correct usage: /bb [option]"
     aliases: [ bb, buildb ]
   buildbattleadmin:
     description: BuildBattle Admin Commands
-    usage: "\u00A76Correct usage: /bba [option]"
+    usage: "§6Correct usage: /bba [option]"
     aliases: [ bba, buildbadmin ]
 
 permissions:

--- a/src/main/resources/rewards.yml
+++ b/src/main/resources/rewards.yml
@@ -2,7 +2,7 @@
 #                    BuildBattle rewards configuration
 #
 #                          Placeholders list:
-#                   %PLAYER% - Current player name
+#                   %player% - Current player name
 #                       %MAPNAME% - Name of map
 #                    %ARENA-ID% - BaseArena Identifier
 #                    %PLACE% - Player Place (Working on category place)
@@ -17,11 +17,11 @@
 #    - chance(1):p:say I was very lucky!              # Player has 1% chance to say "I was very lucky!"
 #    - p:chance(99):spawn                             # Player has 99% chance to teleport to spawn
 #       ^ YOU CAN EVEN SWAP CHANCE WITH PLAYER!
-#    - chance(50):eco give %PLAYER% 10                # Console has 10% chance to give player 10$
+#    - chance(50):eco give %player% 10                # Console has 10% chance to give player 10$
 #
 #   You can unlock full potential of rewards using our script engine! (since 4.0.0)
 #    Just add example reward:
-#    - script:player.sendMessage("oh, hi %PLAYER%");      # It will send "oh, hi <player name>" to player! 100% plain java!
+#    - script:player.sendMessage("oh, hi %player%");      # It will send "oh, hi <player name>" to player! 100% plain java!
 #    - script:server.broadcastMessage("hello everyone");  # Broadcasts "hello everyone" to whole server
 #    - script:player.getInventory().addItem(new org.bukkit.inventory.ItemStack(org.bukkit.Material.DIRT));
 #         ^ Gives player dirt item (you must always use direct package names for not provided objects)
@@ -50,40 +50,40 @@ rewards:
   # Commands performed when all themes are guessed in GTB
   # Delete everything if you don't want to use this section
   guess:
-    - eco give %PLAYER% 2
+    - eco give %player% 2
   guess-all:
-    - eco give %PLAYER% 2
+    - eco give %player% 2
   # Commands executed when someone vote
   vote:
-    - eco give %PLAYER% 2
-    - chance(10):eco give %PLAYER% 8
+    - eco give %player% 2
+    - chance(10):eco give %player% 8
   # Commands executed when all voted for a plot
   vote-all:
-    - eco give %PLAYER% 2
-    - chance(10):eco give %PLAYER% 8
+    - eco give %player% 2
+    - chance(10):eco give %player% 8
   # Commands executed when someone report a building
   report:
-    - eco give %PLAYER% 2
+    - eco give %player% 2
     - script:player.sendMessage("You reported the building");
   # Commands executed on place X
   place:
     1:
-      - eco give %PLAYER% 10
+      - eco give %player% 10
     2:
-      - eco give %PLAYER% 9
+      - eco give %player% 9
     3:
-      - eco give %PLAYER% 8
+      - eco give %player% 8
     4:
-      - eco give %PLAYER% 7
+      - eco give %player% 7
     5:
-      - eco give %PLAYER% 6
+      - eco give %player% 6
     6:
-      - eco give %PLAYER% 5
+      - eco give %player% 5
     7:
-      - eco give %PLAYER% 4
+      - eco give %player% 4
     8:
-      - eco give %PLAYER% 3
+      - eco give %player% 3
     9:
-      - eco give %PLAYER% 2
+      - eco give %player% 2
     10:
-      - eco give %PLAYER% 1
+      - eco give %player% 1

--- a/src/main/resources/special_items.yml
+++ b/src/main/resources/special_items.yml
@@ -121,7 +121,7 @@ Back-To-Hub:
 Options-Menu:
   permission: ""
   execute:
-    - ""
+    - "p:bb menu"
   displayname: "&a&lOptions menu &7(Right Click)"
   lore:
     - "&7Right-click to open options menu"


### PR DESCRIPTION
Hi again, I have been working on resolving some bugs within BuildBattle that I found.
The most noticable error is the Menu Item not working when in-game, so it is impossible to open the BuildBattle menu for players.
I found out the reason for this is that BuildBattle uses the MiniGamesBox API at two different places regarding the menu item.
- It registered it as special item using the API in `registerSpecialItems()` present in `AdditionalValueInitializer.java`
- It registered it as a separate HandlerItem in `getMenuItem()` present in `BaseArena.java`.
The first use did not provide an InteractHandler to the item (it takes it from the `special_items.yml` config and this one is empty), while the second use did actually correctly provide an InteractHandler. However, since it was looped through the array of special items and as soon as a matching ItemStack was found, a menu item having no Interact Handler was picked by the loop and therefore the correct item was dismissed, making the menu item not work anymore.

I have changed this now, such that the second use case is removed from the code and it only registers the menu item as a special item just like any other item. However, since the 'execute' path in `special_items.yml` needs to have some command, I also added an argument to the buildbattle command, namely /bb menu, which allows a player to open the BuildBattle menu. I then added this command argument to the config file and voila, once a player clicks the menu item (only while being in-game of course), the interacthandler properly fires and the Menu Item is fixed! :)

Next to this change, some other fixes have been applied:
- Enderpearls allowed players to teleport through the arena and visit other players plots. It even allowed during voting period to teleport away out of the map. I have disabled throwing enderpearls.
- RespawnAnchors could be loaded all up with glowstone and the explosion was not disabled. It could blow up the entire arena! I have disabled the explosion damage.
- Place rewards were firing multiple times for the same players. So a player ending first place would also receive second place, third place rewards, etc. This was due to incorrect usage of the MiniGamesBox api. It was a quick fix, but it works.
- Only the %player% placeholder works in the config.yml file, not uppercase %PLAYER%. I have changed the default generation of the config to the lowercase variant.
- Clicking on the first clock provided in the time change menu in the BuildBattle menu generated an error. I have resolved this error.

Hopefully these changes are welcome. I have worked quite a bit on them while trying to change as minimal as possible. Only the bare necessities should be fixed by this PR.

Thank you in advance! 😄