### PR TITLE
#patch Back to stability 2.0

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -10,6 +10,24 @@ deploy webhooks to print changelog successfully
 
 That's all, matcher will stop when detects next line started with `###` match
 
+### 5.0.12 Release (17.02.2025)
+* Fixed ItemSpawn on Plotarea also for dropped items by not player related drops
+* Fixed gtb plot reset
+* Fixed gtb Arena CleanUp which results in first round issues at selection of theme etc.
+* Fixed gtb options menu is not showing up for every builder
+* Fixed block destroy drops
+* Fixed a bug on gtb where players were getting points for guess even when they wrote the theme on chat when it was already shown by the plugin
+* Fixed spectator counts on gtb guess
+* Fixed bba settheme command
+* Fixed PlayerHeads on 1.20+
+* Fixed clearing of dropped items on 1.21+
+* Fixed Biomes on 1.21
+* Fixed Banner Building on 1.20+
+* Fixed Creature Spawning outside plots in same world
+* Changed stained glass pane naming to ???
+* Updated to minigamesbox 1.3.16
+
+
 ### 5.0.9 Release (09.07.2024)
 * Updated to minigamesbox 1.3.11
 * Fixed ChunkManager.sendMapChunk

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -24,6 +24,7 @@ That's all, matcher will stop when detects next line started with `###` match
 * Fixed Biomes on 1.21
 * Fixed Banner Building on 1.20+
 * Fixed Creature Spawning outside plots in same world
+* Fixed players are collidable on normal mode
 * Changed stained glass pane naming to ???
 * Updated to minigamesbox 1.3.16
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,7 +49,7 @@ dependencies {
 }
 
 group = "plugily.projects"
-version = "5.0.11"
+version = "5.0.11-SNAPSHOT0"
 description = "BuildBattle"
 
 java {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,7 +49,7 @@ dependencies {
 }
 
 group = "plugily.projects"
-version = "5.0.11-SNAPSHOT0"
+version = "5.0.11-SNAPSHOT1"
 description = "BuildBattle"
 
 java {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,7 +42,7 @@ repositories {
 }
 
 dependencies {
-    implementation("plugily.projects:MiniGamesBox-Classic:1.3.15-SNAPSHOT2") { isTransitive = false }
+    implementation("plugily.projects:MiniGamesBox-Classic:1.3.16") { isTransitive = false }
     compileOnly("io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT")
     compileOnly("net.citizensnpcs:citizensapi:2.0.31-SNAPSHOT")
     compileOnly("org.jetbrains:annotations:24.0.1")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,7 +49,7 @@ dependencies {
 }
 
 group = "plugily.projects"
-version = "5.0.11-SNAPSHOT2"
+version = "5.0.11-SNAPSHOT3"
 description = "BuildBattle"
 
 java {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,7 +42,7 @@ repositories {
 }
 
 dependencies {
-    implementation("plugily.projects:MiniGamesBox-Classic:1.3.15") { isTransitive = false }
+    implementation("plugily.projects:MiniGamesBox-Classic:1.3.15-SNAPSHOT2") { isTransitive = false }
     compileOnly("io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT")
     compileOnly("net.citizensnpcs:citizensapi:2.0.31-SNAPSHOT")
     compileOnly("org.jetbrains:annotations:24.0.1")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,7 +49,7 @@ dependencies {
 }
 
 group = "plugily.projects"
-version = "5.0.11-SNAPSHOT3"
+version = "5.0.11-SNAPSHOT4"
 description = "BuildBattle"
 
 java {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,7 +49,7 @@ dependencies {
 }
 
 group = "plugily.projects"
-version = "5.0.11-SNAPSHOT1"
+version = "5.0.11-SNAPSHOT2"
 description = "BuildBattle"
 
 java {

--- a/src/main/java/plugily/projects/buildbattle/arena/ArenaEvents.java
+++ b/src/main/java/plugily/projects/buildbattle/arena/ArenaEvents.java
@@ -83,6 +83,10 @@ public class ArenaEvents extends PluginArenaEvents {
 
     if(buildPlot != null && buildPlot.getCuboid() != null && buildPlot.getCuboid().isIn(event.getBlock().getLocation())) {
       plugin.getUserManager().getUser(event.getPlayer()).adjustStatistic("BLOCKS_BROKEN", 1);
+      if(event.isDropItems()) {
+        event.setCancelled(true);
+        event.getBlock().setType(Material.AIR);
+      }
       return;
     }
     event.setCancelled(true);

--- a/src/main/java/plugily/projects/buildbattle/arena/ArenaEvents.java
+++ b/src/main/java/plugily/projects/buildbattle/arena/ArenaEvents.java
@@ -84,12 +84,32 @@ public class ArenaEvents extends PluginArenaEvents {
     if(buildPlot != null && buildPlot.getCuboid() != null && buildPlot.getCuboid().isIn(event.getBlock().getLocation())) {
       plugin.getUserManager().getUser(event.getPlayer()).adjustStatistic("BLOCKS_BROKEN", 1);
       if(event.isDropItems()) {
-        event.setCancelled(true);
-        event.getBlock().setType(Material.AIR);
+        event.getBlock().getDrops().clear();
       }
       return;
     }
     event.setCancelled(true);
+  }
+
+  @EventHandler(priority = EventPriority.HIGH)
+  public void onItemSpawn(ItemSpawnEvent event) {
+    if (!plugin.getArenaRegistry().getArenaWorlds().contains(event.getLocation().getWorld())) {
+      return;
+    }
+
+    plugin.getArenaRegistry().getArenas().forEach(arena -> {
+      if(!(arena instanceof BaseArena)) {
+        return;
+      }
+      if(((BaseArena) arena).getArenaInGameState() != BaseArena.ArenaInGameState.BUILD_TIME || plugin.getBlacklistManager().getItemList().contains(event.getEntity().getItemStack().getType())) {
+        return;
+      }
+      for(Plot buildPlot : ((BaseArena) arena).getPlotManager().getPlots()) {
+        if(buildPlot.getCuboid() != null && buildPlot.getCuboid().isInWithMarge(event.getLocation(), 1)) {
+          event.setCancelled(true);
+        }
+      }
+    });
   }
 
   @EventHandler(priority = EventPriority.HIGH)

--- a/src/main/java/plugily/projects/buildbattle/arena/ArenaEvents.java
+++ b/src/main/java/plugily/projects/buildbattle/arena/ArenaEvents.java
@@ -411,9 +411,6 @@ public class ArenaEvents extends PluginArenaEvents {
     if(arena == null || arena.getArenaState() != IArenaState.IN_GAME) {
       return;
     }
-    if(event.getEntity().getType() != EntityType.PLAYER) {
-      return;
-    }
     event.setCancelled(true);
   }
 

--- a/src/main/java/plugily/projects/buildbattle/arena/ArenaEvents.java
+++ b/src/main/java/plugily/projects/buildbattle/arena/ArenaEvents.java
@@ -591,6 +591,9 @@ public class ArenaEvents extends PluginArenaEvents {
     if(arena.getArenaState() != IArenaState.IN_GAME) {
       return;
     }
+    if(arena.getArenaInGameState() != BaseArena.ArenaInGameState.BUILD_TIME) {
+      return;
+    }
     if(arena.getSpectators().contains(player)) {
       return;
     }

--- a/src/main/java/plugily/projects/buildbattle/arena/GuessArena.java
+++ b/src/main/java/plugily/projects/buildbattle/arena/GuessArena.java
@@ -68,9 +68,8 @@ public class GuessArena extends BaseArena {
   @Override
   public void cleanUpArena() {
     currentTheme = null;
+    resetBuildPlot();
     round = 1;
-    whoGuessed.clear();
-    removedCharsAt.clear();
     playedPlots.clear();
     playedThemes.clear();
     super.cleanUpArena();
@@ -138,10 +137,10 @@ public class GuessArena extends BaseArena {
     if(buildPlot != null) {
       buildPlot.resetPlot();
     }
-    getRemovedCharsAt().clear();
+    removedCharsAt.clear();
     setBuildPlot(null);
     setCurrentTheme(null);
-    getWhoGuessed().clear();
+    whoGuessed.clear();
     round += 1;
     getPlayers().forEach(player -> getPlugin().getActionBarManager().clearActionBarsFromPlayer(player));
   }

--- a/src/main/java/plugily/projects/buildbattle/arena/states/build/InGameState.java
+++ b/src/main/java/plugily/projects/buildbattle/arena/states/build/InGameState.java
@@ -66,6 +66,7 @@ public class InGameState extends PluginInGameState {
           for(Player player : pluginArena.getPlayers()) {
             player.closeInventory();
             player.setGameMode(GameMode.CREATIVE);
+            VersionUtils.setCollidable(player, false);
           }
         } else {
           handleThemeVoting(pluginArena);

--- a/src/main/java/plugily/projects/buildbattle/arena/states/guess/InGameState.java
+++ b/src/main/java/plugily/projects/buildbattle/arena/states/guess/InGameState.java
@@ -111,9 +111,7 @@ public class InGameState extends PluginInGameState {
           pluginArena.teleportToWinnerPlot(); //todo save built plot from winner
           pluginArena.executeEndRewards();
           getPlugin().getArenaManager().stopGame(false, arena);
-        }
-//round delay
-        if(arena.getTimer() <= 0) {
+        } else if (arena.getTimer() <= 0) {
           pluginArena.resetBuildPlot();
           setArenaTimer(getPlugin().getConfig().getInt("Time-Manager." + pluginArena.getArenaType().getPrefix() + ".Voting.Theme"));
           pluginArena.setArenaInGameState(BaseArena.ArenaInGameState.THEME_VOTING);

--- a/src/main/java/plugily/projects/buildbattle/arena/states/guess/InGameState.java
+++ b/src/main/java/plugily/projects/buildbattle/arena/states/guess/InGameState.java
@@ -71,7 +71,10 @@ public class InGameState extends PluginInGameState {
           new MessageBuilder("IN_GAME_MESSAGES_PLOT_GTB_ROUND").asKey().integer(pluginArena.getRound()).arena(pluginArena).sendArena();
           new TitleBuilder("IN_GAME_MESSAGES_PLOT_GTB_THEME_GUESS_TITLE").asKey().arena(pluginArena).sendArena();
 
-          Bukkit.getScheduler().runTaskLater(getPlugin(), () -> pluginArena.getCurrentBuilders().forEach(player -> player.setGameMode(GameMode.CREATIVE)), 40);
+          Bukkit.getScheduler().runTaskLater(getPlugin(), () -> pluginArena.getCurrentBuilders().forEach(player -> {
+            player.setGameMode(GameMode.CREATIVE);
+            pluginArena.getPlugin().getSpecialItemManager().getSpecialItem("OPTIONS_MENU").setItem(player);
+          } ), 40);
 
           setArenaTimer(getPlugin().getConfig().getInt("Time-Manager." + pluginArena.getArenaType().getPrefix() + ".In-Game"));
           pluginArena.setArenaInGameState(BaseArena.ArenaInGameState.BUILD_TIME);

--- a/src/main/java/plugily/projects/buildbattle/commands/arguments/game/GuessArgument.java
+++ b/src/main/java/plugily/projects/buildbattle/commands/arguments/game/GuessArgument.java
@@ -57,6 +57,11 @@ public class GuessArgument {
 
         GuessArena gameArena = (GuessArena) arena;
 
+        if(gameArena.getArenaInGameState() != BaseArena.ArenaInGameState.BUILD_TIME) {
+          new MessageBuilder("COMMANDS_NOT_PLAYING").asKey().player(player).sendPlayer();
+          return;
+        }
+
         if(gameArena.getWhoGuessed().contains(player)) {
           new MessageBuilder("IN_GAME_MESSAGES_PLOT_GTB_THEME_GUESS_CANT_TALK").asKey().arena(gameArena).player(player).sendPlayer();
           return;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -67,6 +67,15 @@ Block:
     Leave: false
     # Cancels Item Movement into player crafting, enchantment tables, anvils ...
     Item-Move: true
+    ArmorStand:
+      # Should we block armor stand destroy with double click?
+      Destroy: true
+      # Should we block armor stand interaction?
+      Interact: true
+      # Should these only be blocked while ingame and arena state is in_game? (e.g. Lobby and Ending is blocked)
+      # Setting it to false means on all stages of the game the event will be cancelled.
+      # Setting it to true means only while IN_GAME the event will be cancelled.
+      Check: true
 
 
 # Enable this option when you're using MySQL, otherwise it won't work.
@@ -274,4 +283,4 @@ Update-Notifier:
 # You edited it, huh? Next time hurt yourself!
 Do-Not-Edit:
   File-Version: 1
-  Core-Version: 4
+  Core-Version: 5


### PR DESCRIPTION
* Fixed ItemSpawn on Plotarea also for dropped items by not player related drops
* Fixed gtb plot reset
* Fixed gtb Arena CleanUp which results in first round issues at selection of theme etc.
* Fixed gtb options menu is not showing up for every builder
* Fixed block destroy drops
* Fixed a bug on gtb where players were getting points for guess even when they wrote the theme on chat when it was already shown by the plugin
* Fixed spectator counts on gtb guess
* Fixed bba settheme command
* Fixed PlayerHeads on 1.20+
* Fixed clearing of dropped items on 1.21+
* Fixed Biomes on 1.21
* Fixed Banner Building on 1.20+
* Fixed Creature Spawning outside plots in same world
* Fixed players are collidable on normal mode
* Changed stained glass pane naming to ???
* Updated to minigamesbox 1.3.16